### PR TITLE
Make snapshot package name more readable [4.0 branch]

### DIFF
--- a/prepare-packaging-metadata-jenkins.sh
+++ b/prepare-packaging-metadata-jenkins.sh
@@ -27,7 +27,7 @@ MONO_ROOT=${PACKAGING_ROOT}/../../
 BUILD_ARCH=$(dpkg-architecture -qDEB_BUILD_ARCH)
 #Broken by Jenkins 1.597
 #TIMESTAMP=`echo $BUILD_ID | sed 's/[_-]//g'`
-TIMESTAMP=`date -u +%Y%m%d%H%M%S`
+TIMESTAMP=`date -u +%Y-%m-%dT%H.%M.%S`
 GITSTAMP=`cut -f2 -d'/' mono/mini/version.h | sed 's/\"//'`
 
 echo "Building debian/ folder"

--- a/prepare-specfile-jenkins.sh
+++ b/prepare-specfile-jenkins.sh
@@ -26,7 +26,7 @@ PACKAGING_ROOT="$( cd "$( dirname "$0" )" && pwd )"
 MONO_ROOT=${PACKAGING_ROOT}/../../
 #Broken by Jenkins 1.597
 #TIMESTAMP=`echo $BUILD_ID | sed 's/[_-]//g'`
-TIMESTAMP=`date -u +%Y%m%d%H%M%S`
+TIMESTAMP=`date -u +%Y-%m-%dT%H.%M.%S`
 GITSTAMP=`cut -f2 -d'/' mono/mini/version.h | sed 's/\"//'`
 
 echo "Building spec file"


### PR DESCRIPTION
Instead of mono-snapshot-20150609142403 it's now mono-snapshot-2015-06-09T14.24.16 which is a lot easier to parse for a human.